### PR TITLE
Fix Image rewards bug, improve console output readability, and update output file content

### DIFF
--- a/scripts/classifiers/cafe_aesthetic/score_image_reward.py
+++ b/scripts/classifiers/cafe_aesthetic/score_image_reward.py
@@ -1,10 +1,16 @@
 import os
 import torch
+import math
 import ImageReward as reward
+
+def sigmoid(x):
+    return 1 / (1 + math.exp(-x))
 
 model = None
 def score(image, prompt=""):
     global model
     if model == None:
         model = reward.load("ImageReward-v1.0")
-    return model.score(prompt, image)
+    score_origin = model.score(prompt, image)
+    score = sigmoid(score_origin)
+    return score

--- a/scripts/mbw/auto_mbw.py
+++ b/scripts/mbw/auto_mbw.py
@@ -58,7 +58,7 @@ presetWeights = PresetWeights()
 def on_ui_tabs():
     def create_sampler_and_steps_selection(choices, tabname):
         with FormRow(elem_id=f"sampler_selection_{tabname}"):
-            sampler = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value=choices[0].name)
+            sampler = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value="DPM++ 2M Karras")
             steps = gr.Slider(minimum=1, maximum=150, step=1, elem_id=f"{tabname}_steps", label="Sampling steps", value=20)
         return steps, sampler
     with gr.Column():
@@ -75,11 +75,11 @@ def on_ui_tabs():
                     steps, sampler = create_sampler_and_steps_selection(samplers, "autombw")
                 with FormRow():
                     with gr.Column(elem_id="autombw_column_size", scale=4):
-                        width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=512, elem_id="autombw_width")
-                        height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=512, elem_id="autombw_height")
+                        width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width", value=768, elem_id="autombw_width")
+                        height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height", value=768, elem_id="autombw_height")
                     with gr.Column(elem_id="autombw_column_batch"):
                         batch_count = gr.Slider(minimum=1, step=1, label='Batch count', value=1, elem_id="autombw_batch_count")
-                        batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=1, elem_id="autombw_batch_size")
+                        batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size', value=8, elem_id="autombw_batch_size")
                 cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="autombw_cfg_scale")
                 with gr.Row():
                     chk_keep_random_seed = gr.Checkbox(label="Keep random seed", value=False)
@@ -116,7 +116,7 @@ def on_ui_tabs():
                     with gr.Column():
                         sl_B_ALL = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="Test Base", value=0, elem_id="autombw_test_base")
                         with gr.Row():
-                            chk_base_alpha = gr.Checkbox(label="base_alpha", value=True, elem_id="autombw_base_alpha")
+                            chk_base_alpha = gr.Checkbox(label="base_alpha", value=False, elem_id="autombw_base_alpha")
                             sl_base_alpha = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="base_alpha", value=0, elem_id="autombw_base_alpha_sl")
                     chk_verbose_mbw = gr.Checkbox(label="verbose console", value=False, elem_id="autombw_verbose_mbw")
                     chk_allow_overwrite = gr.Checkbox(label="Allow overwrite", value=True, interactive=False, elem_id="autombw_allow_overwrite")
@@ -125,23 +125,23 @@ def on_ui_tabs():
                     with gr.Column():
                         with gr.Row():
                             chk_save_as_half = gr.Checkbox(label="Save as half", value=True, elem_id="autombw_save_as_half")
-                            chk_save_as_safetensors = gr.Checkbox(label="Save as safetensors", value=False, elem_id="autombw_save_as_safetensors")
-                            chk_save_output_images = gr.Checkbox(label="Save output images", value=False, elem_id="autombw_save_output_images")
+                            chk_save_as_safetensors = gr.Checkbox(label="Save as safetensors", value=True, elem_id="autombw_save_as_safetensors")
+                            chk_save_output_images = gr.Checkbox(label="Save output images", value=True, elem_id="autombw_save_output_images")
                     with gr.Column():
-                        radio_position_ids = gr.Radio(label="Skip/Reset CLIP position_ids", choices=["None", "Skip", "Force Reset"], value="None", type="index", elem_id="autombw_position_ids")
+                        radio_position_ids = gr.Radio(label="Skip/Reset CLIP position_ids", choices=["None", "Skip", "Force Reset"], value="Skip", type="index", elem_id="autombw_position_ids")
                     with gr.Column():
                         with gr.Row():
                             dropdown_search_type = gr.Dropdown(label="Search Type", choices=["Linear", "Binary Mid Pass", "Binary", "Linear 2x", "Binary Mid Pass 2x", "Binary 2x"], value="Binary Mid Pass 2x", elem_id="autombw_search_type")
                         with gr.Row():
-                            dropdown_classifiers = gr.Dropdown(label='Classifier', elem_id="autombw_classifiers", choices=[*discovered_plugins.keys()], value=[*discovered_plugins.keys()][0])
+                            dropdown_classifiers = gr.Dropdown(label='Classifier', elem_id="autombw_classifiers", choices=[*discovered_plugins.keys()], value="score_image_reward")
                     with gr.Column():
                         with gr.Row():
                             tally_types = ["Arithmetic Mean", "Geometric Mean", "Harmonic Mean", "A/G Mean", "G/H Mean", "A/H Mean",  "Median", "Min", "Max", "Min*Max", "Fuzz Mode"]
                             dropdown_tally_type = gr.Dropdown(label="Tally Type", choices=tally_types, value="Arithmetic Mean", elem_id="autombw_tally_type")
-                            dropdown_tally_type_2 = gr.Dropdown(label="Tally Type 2", choices=tally_types, value="Arithmetic Mean", elem_id="autombw_tally_type_2")
-                            dropdown_tally_type_3 = gr.Dropdown(label="Tally Type 3", choices=tally_types, value="Arithmetic Mean", elem_id="autombw_tally_type_3")
+                            dropdown_tally_type_2 = gr.Dropdown(label="Tally Type 2", choices=tally_types, value="Geometric Mean", elem_id="autombw_tally_type_2")
+                            dropdown_tally_type_3 = gr.Dropdown(label="Tally Type 3", choices=tally_types, value="Harmonic Mean", elem_id="autombw_tally_type_3")
                         with gr.Row():
-                            dropdown_pass_count = gr.Dropdown(label="Passes", choices=['Singlepass', 'Doublepass', 'Triplepass'], value='Singlepass', elem_id="autombw_pass_count", type="index")
+                            dropdown_pass_count = gr.Dropdown(label="Passes", choices=['Singlepass', 'Doublepass', 'Triplepass'], value='Triplepass', elem_id="autombw_pass_count", type="index")
         with gr.Row():
             model_A = gr.Dropdown(label="Model A", choices=sd_models.checkpoint_tiles(), elem_id="autombw_model_a")
             model_B = gr.Dropdown(label="Model B", choices=sd_models.checkpoint_tiles(), elem_id="autombw_model_b")
@@ -500,6 +500,16 @@ def on_ui_tabs():
 
             # save log to history.tsv
             weight_name = ""
+            testMergeHistory.add_history(
+                base_alpha,
+                _weights,
+                "",
+                weight_name,
+                local_dropdown_tally_type,
+                testscore,
+                positive_prompt,
+                negative_prompt
+                )
             if final:
                 sd_models.list_models()
                 model_A_info = sd_models.get_closet_checkpoint_match(model_A)
@@ -531,16 +541,6 @@ def on_ui_tabs():
                         )
                 return ret_html
             else:
-                testMergeHistory.add_history(
-                    base_alpha,
-                    _weights,
-                    "",
-                    weight_name,
-                    local_dropdown_tally_type,
-                    testscore,
-                    positive_prompt,
-                    negative_prompt
-                    )
                 return testscore
 
         def arrange_keys(keys, testval):

--- a/scripts/mbw/auto_mbw.py
+++ b/scripts/mbw/auto_mbw.py
@@ -286,9 +286,6 @@ def on_ui_tabs():
             multi_model_B = [model_B]
             multi_model_O = [txt_model_O]
 
-        #weird webui replacement shenanigans
-        random_number = 0
-
         #seed settings
         if chk_keep_random_seed == True:
             seed = -1
@@ -363,13 +360,8 @@ def on_ui_tabs():
 
                 #to get around webui not handling replacements correctly
                 if not final:
-                    nonlocal random_number
-                    while True:
-                        local_random_number = random.randint(0, 1000)
-                        if local_random_number != random_number:
-                            random_number = local_random_number
-                            break
-                    _footer = _footer + str(random_number)
+                    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+                    _footer = _footer + str(timestamp)
 
                 if filename_ext in [".safetensors", ".ckpt"]:
                     _ret = f"{filename_body}{_footer}{filename_ext}"
@@ -482,7 +474,7 @@ def on_ui_tabs():
                     if os.path.islink(_output):
                         os.remove(os.path.realpath(_output))
                     os.remove(_output)
-                print("test score: " + str(testscore))
+                print(local_dropdown_tally_type + " test score: " + str(testscore))
                 refresh_models()
                 if chk_save_output_images:
                     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -544,6 +536,8 @@ def on_ui_tabs():
                     _weights,
                     "",
                     weight_name,
+                    local_dropdown_tally_type,
+                    testscore,
                     positive_prompt,
                     negative_prompt
                     )
@@ -675,6 +669,7 @@ def on_ui_tabs():
             savedweights = [float(n) for n in [*sliders.values()]]
             scores = {}
             for current_pass in range(dropdown_pass_count + 1):
+                print("current_pass:" + str(current_pass))
                 if chk_multi_pass_seed_progessive == True and seed != -1:
                     seed = seed + 1
                 #prechks - base alpha & m00

--- a/scripts/mbw_each/auto_mbw_mod.py
+++ b/scripts/mbw_each/auto_mbw_mod.py
@@ -556,6 +556,16 @@ def on_ui_tabs():
 
             # save log to history.tsv
             weight_name = ""
+            testMergeHistory.add_history(
+                base_alpha,
+                _weights_a,
+                _weights_b,
+                weight_name,
+                local_dropdown_tally_type,
+                testscore,
+                positive_prompt,
+                negative_prompt
+                )
             if final:
                 sd_models.list_models()
                 model_A_info = sd_models.get_closet_checkpoint_match(model_A)
@@ -587,16 +597,6 @@ def on_ui_tabs():
                         )
                 return ret_html
             else:
-                testMergeHistory.add_history(
-                    base_alpha,
-                    _weights_a,
-                    _weights_b,
-                    weight_name,
-                    local_dropdown_tally_type,
-                    testscore,
-                    positive_prompt,
-                    negative_prompt
-                    )
                 return testscore
 
         def arrange_keys(keys, testval):

--- a/scripts/mbw_each/auto_mbw_mod.py
+++ b/scripts/mbw_each/auto_mbw_mod.py
@@ -326,9 +326,6 @@ def on_ui_tabs():
             multi_model_B = [model_B]
             multi_model_O = [txt_model_O]
 
-        #weird webui replacement shenanigans
-        random_number = 0
-
         #seed settings
         if chk_keep_random_seed == True:
             seed = -1
@@ -420,13 +417,8 @@ def on_ui_tabs():
 
                 #to get around webui not handling replacements correctly
                 if not final:
-                    nonlocal random_number
-                    while True:
-                        local_random_number = random.randint(0, 1000)
-                        if local_random_number != random_number:
-                            random_number = local_random_number
-                            break
-                    _footer = _footer + str(random_number)
+                    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+                    _footer = _footer + str(timestamp)
 
                 if filename_ext in [".safetensors", ".ckpt"]:
                     _ret = f"{filename_body}{_footer}{filename_ext}"
@@ -536,7 +528,7 @@ def on_ui_tabs():
                     if os.path.islink(_output):
                         os.remove(os.path.realpath(_output))
                     os.remove(_output)
-                print("test score: " + str(testscore))
+                print(local_dropdown_tally_type + " test score: " + str(testscore))
                 refresh_models()
                 if chk_save_output_images:
                     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -600,6 +592,8 @@ def on_ui_tabs():
                     _weights_a,
                     _weights_b,
                     weight_name,
+                    local_dropdown_tally_type,
+                    testscore,
                     positive_prompt,
                     negative_prompt
                     )
@@ -847,6 +841,7 @@ def on_ui_tabs():
             saved_base_alpha = sl_base_alpha
             scores = {}
             for current_pass in range(dropdown_pass_count + 1):
+                print("current_pass:" + str(current_pass))
                 if chk_multi_pass_seed_progessive == True and seed != -1:
                     seed = seed + 1
                 #prechks - base alpha & m00

--- a/scripts/mbw_util/test_merge_history.py
+++ b/scripts/mbw_util/test_merge_history.py
@@ -12,7 +12,7 @@ from modules import scripts
 CSV_FILE_ROOT = "csv/"
 CSV_FILE_PATH = "csv/test_history.tsv"
 HEADERS = [
-        "base_alpha", "weight_name", "weight_values", "weight_values2", "datetime", "positive_prompt", "negative_prompt"]
+        "base_alpha", "weight_name", "weight_values", "weight_values2", "local_dropdown_tally_type", "testscore" , "datetime", "positive_prompt", "negative_prompt"]
 path_root = scripts.basedir()
 
 class TestMergeHistory():
@@ -29,6 +29,8 @@ class TestMergeHistory():
                 weight_value_A,
                 weight_value_B,
                 weight_name,
+                local_dropdown_tally_type,
+                testscore,
                 positive_prompt, negative_prompt):
         _history_dict = {}
         _history_dict.update({
@@ -36,6 +38,8 @@ class TestMergeHistory():
             "weight_name": weight_name,
             "weight_values": weight_value_A,
             "weight_values2": weight_value_B,
+            "local_dropdown_tally_type": local_dropdown_tally_type,
+            "testscore": testscore, 
             "datetime": f"{datetime.datetime.now()}",
             "positive_prompt": positive_prompt,
             "negative_prompt": negative_prompt


### PR DESCRIPTION
Image rewards can result in negative scores, causing errors in some tally type. Normalize them using the sigmoid function. 
Display the current pass and the name of the tally type used in console output
Record test scores and the the name of the tally type used in the test history for convenient comparison
Adjust model naming to include datetime for simplified model identification.